### PR TITLE
Allow to combine --no-default-features with a custom feature set.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -613,12 +613,17 @@ fn get_cargo_args(args: &Args) -> Vec<String> {
         list.push(format!("--example={}", example));
     }
 
-    if let Some(ref features) = args.features {
-        list.push(format!("--features={}", features));
-    } else if args.all_features {
+    if args.all_features {
         list.push("--all-features".to_string());
-    } else if args.no_default_features {
-        list.push("--no-default-features".to_string());
+    } else {
+
+        if args.no_default_features {
+            list.push("--no-default-features".to_string());
+        }
+
+        if let Some(ref features) = args.features {
+            list.push(format!("--features={}", features));
+        }
     }
 
     if let Some(ref target) = args.target {


### PR DESCRIPTION
The current argument validation doesn't allow to use cargo-bloat on custom feature sets as this would require to combine `--no-default-arguments` with the `--features` flag but both are currently mutually exclusive.

This patch will change this behavior and allow them to appear at the same time.