### PR TITLE
Add xargo support to cargo-bloat

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,21 @@ fn wrapper_mode(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn stdlibs_dir(target_triple: &str) -> Result<path::PathBuf, Error> {
+    // Support xargo by applying the rustflags
+    // This is meant to match how cargo handles the RUSTFLAG environment
+    // variable.
+    // See https://github.com/rust-lang/cargo/blob/69aea5b6f69add7c51cca939a79644080c0b0ba0/src/cargo/core/compiler/build_context/target_info.rs#L434-L441
+    let rustflags = std::env::var("RUSTFLAGS")
+        .unwrap_or("".to_string());
+
+    let rustflags = rustflags
+        .split(' ')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(AsRef::<std::ffi::OsStr>::as_ref);
+
     let output = Command::new("rustc")
+        .args(rustflags)
         .arg("--print=sysroot").output()
         .map_err(|_| Error::RustcFailed)?;
 


### PR DESCRIPTION
Apply the RUSTFLAGS when calling to rustc to recover the sysroot in order to find the std. Allows using `xargo bloat --target some-custom-target`