### PR TITLE
Fix enabling regex filtering by default to actually do that.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ default-features = false
 features = ["std"]
 
 [features]
-default = ["regex"]
+default = ["regex-filter"]
 regex-filter = ["regex"]


### PR DESCRIPTION
ecf516b109dc3996b44d4acc4bf2bd0e9b1bb71c enabled the regex dependency
by default but left the regex-filter feature itself disabled. But the code uses
the regex-filter feature, not the regex feature, to enable support for
regex filtering. So this change enables the regex-filter feature by default
instead.