### PR TITLE
Add basic support for PDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,10 +16,17 @@ dependencies = [
  "json",
  "memmap2",
  "multimap",
+ "pdb",
  "pico-args",
  "regex",
  "term_size",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "json"
@@ -49,6 +56,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "pdb"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
+dependencies = [
+ "fallible-iterator",
+ "scroll",
+ "uuid",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +88,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+
+[[package]]
 name = "term_size"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +102,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ multimap = { version = "0.8", default-features = false }
 pico-args = "0.4.2"
 term_size = "0.3.1"
 binfarce = "0.2.1"
-pdb="0.7.0"
+pdb = "0.7.0"
 
 [dependencies.regex]
 version = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ multimap = { version = "0.8", default-features = false }
 pico-args = "0.4.2"
 term_size = "0.3.1"
 binfarce = "0.2.1"
+pdb="0.7.0"
 
 [dependencies.regex]
 version = "1.3"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Inspired by [google/bloaty](https://github.com/google/bloaty).
 
 **Note:** supports ELF (Linux, BSD), Mach-O (macOS) and PE (Windows) binaries.
 
-**Note:** Windows MSVC target is not supported. See [#17](https://github.com/RazrFalcon/cargo-bloat/issues/17).
-
 **Note:** WASM is not supported. Prefer [twiggy](https://github.com/rustwasm/twiggy) instead.
 
 ### Install

--- a/src/main.rs
+++ b/src/main.rs
@@ -865,13 +865,142 @@ fn collect_macho_data(data: &[u8]) -> Result<Data, Error> {
     Ok(d)
 }
 
+fn collect_pdb_data(pdb_path: &path::Path, text_size: u64) -> Result<Data, Error> {
+    use pdb::FallibleIterator;
+
+    let file = std::fs::File::open(&pdb_path).map_err(|_| Error::OpenFailed(pdb_path.to_owned()))?;
+    let mut pdb = pdb::PDB::open(file)?;
+
+    let dbi = pdb.debug_information()?;
+    let symbol_table = pdb.global_symbols()?;
+    let address_map = pdb.address_map()?;
+
+    let mut out_symbols = Vec::new();
+
+    // Collect the PublicSymbols
+    let mut public_symbols = Vec::new();
+
+    let mut symbols = symbol_table.iter();
+    while let Ok(Some(symbol)) = symbols.next() {
+        match symbol.parse() {
+            Ok(pdb::SymbolData::Public(data)) => {
+                if data.code || data.function {
+                    public_symbols.push((data.offset, data.name.to_string().into_owned()));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut modules = dbi.modules()?;
+    while let Some(module) = modules.next()? {
+        let info = match pdb.module_info(&module)? {
+            Some(info) => info,
+            None => continue,
+        };
+        let mut symbols = info.symbols()?;
+        while let Some(symbol) = symbols.next()? {
+            if let Ok(pdb::SymbolData::Public(data)) = symbol.parse() {
+                if data.code || data.function {
+                    public_symbols.push((data.offset, data.name.to_string().into_owned()));
+                }
+            }
+        }
+    }
+
+    let cmp_offsets = |a: &pdb::PdbInternalSectionOffset, b: &pdb::PdbInternalSectionOffset| {
+        a.section.cmp(&b.section).then(a.offset.cmp(&b.offset))
+    };
+    public_symbols.sort_unstable_by(|a, b| cmp_offsets(&a.0, &b.0));
+
+    // Now find the Procedure symbols in all modules
+    // and if possible the matching PublicSymbol record with the mangled name
+    let mut handle_proc = |proc: pdb::ProcedureSymbol| {
+        let mangled_symbol = public_symbols
+            .binary_search_by(|probe| {
+                let low = cmp_offsets(&probe.0, &proc.offset);
+                let high = cmp_offsets(&probe.0, &(proc.offset + proc.len));
+
+                use std::cmp::Ordering::*;
+                match (low, high) {
+                    // Less than the low bound -> less
+                    (Less, _) => Less,
+                    // More than the high bound -> greater
+                    (_, Greater) => Greater,
+                    _ => Equal,
+                }
+            })
+            .ok()
+            .map(|x| &public_symbols[x]);
+
+        let demangled_name = proc.name.to_string().into_owned();
+        out_symbols.push((
+            proc.offset.to_rva(&address_map),
+            proc.len as u64,
+            demangled_name,
+            mangled_symbol,
+        ));
+    };
+
+    let mut symbols = symbol_table.iter();
+    while let Ok(Some(symbol)) = symbols.next() {
+        if let Ok(pdb::SymbolData::Procedure(proc)) = symbol.parse() {
+            handle_proc(proc);
+        }
+    }
+    let mut modules = dbi.modules()?;
+    while let Some(module) = modules.next()? {
+        let info = match pdb.module_info(&module)? {
+            Some(info) => info,
+            None => continue,
+        };
+
+        let mut symbols = info.symbols()?;
+
+        while let Some(symbol) = symbols.next()? {
+            if let Ok(pdb::SymbolData::Procedure(proc)) = symbol.parse() {
+                handle_proc(proc);
+            }
+        }
+    }
+
+    let d = Data {
+        symbols: out_symbols
+            .into_iter()
+            .filter_map(|(address, size, unmangled_name, mangled_name)| {
+                if let Some(address) = address {
+                    Some(SymbolData {
+                        name: mangled_name
+                            .map(|(_, mangled_name)| {
+                                binfarce::demangle::SymbolName::demangle(mangled_name)
+                            })
+                            // Assume the Symbol record name is unmangled if we didn't find one
+                            .unwrap_or(binfarce::demangle::SymbolName {
+                                complete: unmangled_name.clone(),
+                                trimmed: unmangled_name.clone(),
+                                crate_name: None,
+                                kind: binfarce::demangle::Kind::V0,
+                            }),
+                        address: address.0 as u64,
+                        size,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect(),
+        file_size: 0,
+        text_size,
+    };
+
+    Ok(d)
+}
+
 fn collect_pe_data(path: &path::Path, data: &[u8]) -> Result<Data, Error> {
     let (symbols, text_size) = pe::parse(data)?.symbols()?;
 
     // `pe::parse` will return zero symbols for an executable built with MSVC.
     if symbols.is_empty() {
-        use pdb::FallibleIterator;
-
         let pdb_path = {
             let file_name = if let Some(file_name) = path.file_name() {
                 if let Some(file_name) = file_name.to_str() {
@@ -884,146 +1013,14 @@ fn collect_pe_data(path: &path::Path, data: &[u8]) -> Result<Data, Error> {
             };
             path.with_file_name(file_name).with_extension("pdb")
         };
-        let file = std::fs::File::open(&pdb_path).unwrap();
-        let mut pdb = pdb::PDB::open(file)?;
 
-        let dbi = pdb.debug_information()?;
-        let symbol_table = pdb.global_symbols()?;
-        let address_map = pdb.address_map()?;
-
-        let mut out_symbols = vec![];
-
-        // Collect the PublicSymbols
-        let mut public_symbols = vec![];
-
-        let mut symbols = symbol_table.iter();
-        while let Ok(Some(symbol)) = symbols.next() {
-            match symbol.parse() {
-                Ok(pdb::SymbolData::Public(data)) => {
-                    if data.code || data.function {
-                        public_symbols.push((data.offset, data.name.to_string().into_owned()));
-                    }
-                    if data.name.to_string().contains("try_small_punycode_decode") {
-                        dbg!(&data);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let mut modules = dbi.modules()?;
-        while let Some(module) = modules.next()? {
-            let info = match pdb.module_info(&module)? {
-                Some(info) => info,
-                None => continue,
-            };
-            let mut symbols = info.symbols()?;
-            while let Some(symbol) = symbols.next()? {
-                if let Ok(pdb::SymbolData::Public(data)) = symbol.parse() {
-                    if data.code || data.function {
-                        public_symbols.push((data.offset, data.name.to_string().into_owned()));
-                    }
-                    if data.name.to_string().contains("try_small_punycode_decode") {
-                        dbg!(&data);
-                    }
-                }
-            }
-        }
-
-        let cmp_offsets = |a: &pdb::PdbInternalSectionOffset, b: &pdb::PdbInternalSectionOffset| {
-            a.section.cmp(&b.section).then(a.offset.cmp(&b.offset))
-        };
-        public_symbols.sort_unstable_by(|a, b| cmp_offsets(&a.0, &b.0));
-
-        // Now find the Procedure symbols in all modules
-        // and if possible the matching PublicSymbol record with the mangled name
-        let mut handle_proc = |proc: pdb::ProcedureSymbol| {
-            let mangled_symbol = public_symbols
-                .binary_search_by(|probe| {
-                    let low = cmp_offsets(&probe.0, &proc.offset);
-                    let high = cmp_offsets(&probe.0, &(proc.offset + proc.len));
-
-                    use std::cmp::Ordering::*;
-                    match (low, high) {
-                        // Less than the low bound -> less
-                        (Less, _) => Less,
-                        // More than the high bound -> greater
-                        (_, Greater) => Greater,
-                        _ => Equal,
-                    }
-                })
-                .ok()
-                .map(|x| &public_symbols[x]);
-
-            let demangled_name = proc.name.to_string().into_owned();
-            out_symbols.push((
-                proc.offset.to_rva(&address_map),
-                proc.len as u64,
-                demangled_name,
-                mangled_symbol,
-            ));
-        };
-
-        let mut symbols = symbol_table.iter();
-        while let Ok(Some(symbol)) = symbols.next() {
-            if let Ok(pdb::SymbolData::Procedure(proc)) = symbol.parse() {
-                handle_proc(proc);
-            }
-        }
-        let mut modules = dbi.modules()?;
-        while let Some(module) = modules.next()? {
-            let info = match pdb.module_info(&module)? {
-                Some(info) => info,
-                None => continue,
-            };
-
-            let mut symbols = info.symbols()?;
-
-            while let Some(symbol) = symbols.next()? {
-                if let Ok(pdb::SymbolData::Procedure(proc)) = symbol.parse() {
-                    handle_proc(proc);
-                }
-            }
-        }
-
-        let d = Data {
-            symbols: out_symbols
-                .into_iter()
-                .filter_map(|(address, size, unmangled_name, mangled_name)| {
-                    if let Some(address) = address {
-                        Some(SymbolData {
-                            name: mangled_name
-                                .map(|(_, mangled_name)| {
-                                    binfarce::demangle::SymbolName::demangle(mangled_name)
-                                })
-                                // Assume the Symbol record name is unmangled if we didn't find one
-                                .unwrap_or(binfarce::demangle::SymbolName {
-                                    complete: unmangled_name.clone(),
-                                    trimmed: unmangled_name.clone(),
-                                    crate_name: None,
-                                    kind: binfarce::demangle::Kind::V0,
-                                }),
-                            address: address.0 as u64,
-                            size,
-                        })
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            file_size: 0,
-            text_size,
-        };
-
-        Ok(d)
+        collect_pdb_data(&pdb_path, text_size)
     } else {
-        let d = Data {
+        Ok(Data {
             symbols,
             file_size: 0,
             text_size,
-        };
-
-        Ok(d)
+        })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -997,9 +997,12 @@ fn collect_pe_data(path: &path::Path, data: &[u8]) -> Result<Data, Error> {
                                     binfarce::demangle::SymbolName::demangle(mangled_name)
                                 })
                                 // Assume the Symbol record name is unmangled if we didn't find one
-                                .unwrap_or(binfarce::demangle::SymbolName::demangle(
-                                    &unmangled_name,
-                                )),
+                                .unwrap_or(binfarce::demangle::SymbolName {
+                                    complete: unmangled_name.clone(),
+                                    trimmed: unmangled_name.clone(),
+                                    crate_name: None,
+                                    kind: binfarce::demangle::Kind::V0,
+                                }),
                             address: address.0 as u64,
                             size,
                         })


### PR DESCRIPTION
See https://github.com/RazrFalcon/cargo-bloat/issues/17, I think this may be ready to merge as-is but it seems to be missing quite a few symbols. Not sure if merging initial support and possible improvements later is preferred, or waiting to see if we can get a better implementation.

Example output on this crate:

```
D:\dev\cargo-bloat [master ↑2]> cargo run ; cargo run --release -- --release
   Compiling cargo-bloat v0.10.1 (D:\dev\cargo-bloat)
    Finished dev [unoptimized + debuginfo] target(s) in 1.27s
     Running `target\debug\cargo-bloat.exe`
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
    Analyzing target\debug\cargo-bloat.exe

 File  .text    Size         Crate Name
 1.1%   1.4% 28.1KiB          json json::parser::Parser::parse
 0.5%   0.7% 13.2KiB          json json::util::print_dec::write
 0.5%   0.6% 11.8KiB  cargo_bloat? cargo_bloat::process_crate
 0.5%   0.6% 11.7KiB          json json::codegen::Generator::write_json
 0.5%   0.6% 11.6KiB          std? std::sys::windows::process::Command::spawn
 0.5%   0.6% 11.6KiB  cargo_bloat? cargo_bloat::parse_args
 0.4%   0.5% 10.6KiB  cargo_bloat? cargo_bloat::collect_pe_data
 0.3%   0.4%  8.0KiB           pdb <pdb::symbol::SymbolData as scroll::ctx::TryFromCtx>::try_from_ctx
 0.3%   0.4%  7.0KiB  regex_syntax <regex_syntax::hir::translate::TranslatorI as regex_syntax::ast::visitor::Visitor>::visit_class_set_item_post
 0.3%   0.3%  6.8KiB regex_syntax? regex_syntax::ast::parse::ParserI<ref_mut$<regex_syntax::ast::parse::Parser> >::parse_with_comments<ref_mut$<regex_syntax::ast::parse::Parser> >
 0.3%   0.3%  6.6KiB  regex_syntax <regex_syntax::hir::translate::TranslatorI as regex_syntax::ast::visitor::Visitor>::visit_post
 0.2%   0.3%  5.3KiB          std? alloc::collections::btree::map::BTreeMap::insert<std::sys::windows::process::EnvKey,std::ffi::os_str::OsString>
 0.2%   0.3%  5.3KiB         regex regex::exec::ExecBuilder::build
 0.2%   0.3%  5.3KiB           std core::num::flt2dec::strategy::dragon::format_shortest
 0.2%   0.3%  5.3KiB          std? alloc::collections::btree::map::BTreeMap::insert<std::sys::windows::process::EnvKey,enum$<core::option::Option<std::ffi::os_str::OsString>, 1, 1844674...
 0.2%   0.2%  4.7KiB  regex_syntax alloc::str::join_generic_copy
 0.2%   0.2%  4.5KiB      binfarce <binfarce::demangle::legacy::Demangle as core::fmt::Display>::fmt
 0.2%   0.2%  4.4KiB  cargo_bloat? cargo_bloat::main
 0.2%   0.2%  4.4KiB      binfarce binfarce::pe::Pe::symbols
 0.2%   0.2%  4.4KiB           std core::num::flt2dec::strategy::dragon::format_exact
69.2%  86.9%  1.7MiB               And 10270 smaller methods. Use -n N to show more.
79.6% 100.0%  1.9MiB               .text section size, the file size is 2.4MiB
   Compiling cargo-bloat v0.10.1 (D:\dev\cargo-bloat)
    Finished release [optimized] target(s) in 4.32s
     Running `target\release\cargo-bloat.exe --release`
    Finished release [optimized] target(s) in 0.02s
    Analyzing target\release\cargo-bloat.exe

 File  .text     Size Crate Name
 1.2%   1.6%  11.6KiB  std? std::sys::windows::process::Command::spawn
 0.6%   0.7%   5.3KiB  std? alloc::collections::btree::map::BTreeMap::insert<std::sys::windows::process::EnvKey,std::ffi::os_str::OsString>
 0.6%   0.7%   5.3KiB   std core::num::flt2dec::strategy::dragon::format_shortest
 0.6%   0.7%   5.3KiB  std? alloc::collections::btree::map::BTreeMap::insert<std::sys::windows::process::EnvKey,enum$<core::option::Option<std::ffi::os_str::OsString>, 1, 18446744073709...
 0.5%   0.6%   4.4KiB   std core::num::flt2dec::strategy::dragon::format_exact
 0.4%   0.5%   3.8KiB  std? rustc_demangle::v0::Printer::print_type
 0.3%   0.4%   3.3KiB   std rustc_demangle::demangle
 0.3%   0.4%   3.2KiB  std? std::sys::windows::process::Stdio::to_handle
 0.3%   0.4%   3.1KiB   std <rustc_demangle::legacy::Demangle as core::fmt::Display>::fmt
 0.3%   0.4%   3.0KiB   std std::process::Child::wait_with_output
 0.3%   0.4%   2.9KiB  std? rustc_demangle::v0::Printer::print_const
 0.3%   0.3%   2.6KiB  std? rustc_demangle::v0::Printer::print_path
 0.3%   0.3%   2.5KiB   std std::env::args_os
 0.2%   0.3%   2.3KiB   std core::num::flt2dec::strategy::grisu::format_shortest_opt
 0.2%   0.3%   2.1KiB  std? std::sys::windows::process::make_command_line::append_arg
 0.2%   0.2%   1.6KiB  std? std::backtrace_rs::print::BacktraceFrameFmt::print_raw_with_column
 0.2%   0.2%   1.6KiB  std? alloc::collections::btree::node::Handle::remove_leaf_kv<std::sys::windows::process::EnvKey,std::ffi::os_str::OsString,alloc::collections::btree::map::entry::...
 0.2%   0.2%   1.5KiB  std? std::panicking::default_hook
 0.2%   0.2%   1.5KiB   std <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
 0.2%   0.2%   1.5KiB  std? rustc_demangle::v0::impl$6::print_type::closure$0
12.6%  16.2% 121.3KiB       And 518 smaller methods. Use -n N to show more.
78.2% 100.0% 751.0KiB       .text section size, the file size is 960.5KiB
```