### PR TITLE
Bump actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build
       run: cargo build


### PR DESCRIPTION
CI scrips are easy to forget during normal dependency updates, so I thought I'd make a PR.