### PR TITLE
Strip debuginfo and enable thinlto in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ readme = "README.md"
 license = "MIT"
 edition = "2018"
 
+[profile.release]
+strip = "debuginfo"
+lto = "thin"
+
 [dependencies]
 json = "0.12"
 memmap2 = "0.5"


### PR DESCRIPTION
Reduces the size of the resulting binary from 4.6 MiB to 1.3 MiB at the cost of 200-400 ms of
compile time.
Using fat lto would save an additional 220 KiB, but at the cost of ~7s or ~46% longer compile time.
Stripping symbols too could save another 165 KiB and bring the binary down to 958 KiB, but breaking
cargo-bloat on cargo-bloat isn't worth it.

---

Let me know if you'd prefer me to use fat lto.